### PR TITLE
Fixes some references on primality-test README

### DIFF
--- a/2-primality-test/README.md
+++ b/2-primality-test/README.md
@@ -6,16 +6,14 @@
 Objetivo desse desafio é descobrir se um numero é primo ou não.
 Alguns algoritmos de primality são [Fermat](https://en.wikipedia.org/wiki/Fermat_primality_test),[AKS](https://en.wikipedia.org/wiki/AKS_primality_test), [Sieve of Erastosthenes](https://en.wikipedia.org/wiki/Sieve_of_Eratosthenes)
 
-mschonfinkel
-
 | User        | Solution           |
 | ------------- |:-------------:|
 | [anabastos](https://github.com/anabastos) | [Clojure](https://github.com/lambda-study-group/desafios/tree/master/2-primality-test/anabastos) |
 | [mracos](https://github.com/mracos) | [Elixir](https://github.com/lambda-study-group/desafios/tree/master/2-primality-test/mracos) |
 | [appositum](https://github.com/appositum) | [Elixir](https://github.com/lambda-study-group/desafios/tree/master/2-primality-test/appositum) |
 | [v0idpwn](https://github.com/v0idpwn) | [Haskell](https://github.com/lambda-study-group/desafios/tree/master/2-primality-test/v0idpwn) |
-| [caioluiz](https://github.com/caioluiz) | [Elixir](https://github.com/lambda-study-group/desafios/tree/master/2-primality-test/caioluz) |
-| [mschonfinkel](https://github.com/mschonfinkel) | [Elixir](https://github.com/lambda-study-group/desafios/tree/master/2-primality-test/mschonfinkel) |
+| [caioluiz](https://github.com/caioluiz) | [Elixir](https://github.com/lambda-study-group/desafios/tree/master/2-primality-test/caioluiz) |
+| [mschonfinkel](https://github.com/mschonfinkel) | [Haskell](https://github.com/lambda-study-group/desafios/tree/master/2-primality-test/mschonfinkel) |
 
 **Input**: Numero inteiro
 **Output**: Bool(Se é primo ou não)


### PR DESCRIPTION
* caioluiz's implementation had the wrong link;
* mschonfinkel' implementation was made on Haskell instead of Elixir;
* Deletes a spare string on the description